### PR TITLE
SEO Improvement: Allow search engines to index includes folder

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -22,7 +22,6 @@ Disallow:
 User-Agent: *
 Disallow: /config/
 Disallow: /handlers/
-Disallow: /includes/
 Disallow: /interceptors/
 Disallow: /layouts/
 Disallow: /logs/


### PR DESCRIPTION
# Description

Allow search engines to index the "includes" folder, which conventionally holds static assets, like images.

Allowing static assets like images, JS, CSS, fonts, and favicons to be indexed by search engines benefits SEO because these assets help search engines more accurately understand and render a site’s content. When crawlers can access your CSS and JavaScript, for instance, they can detect mobile responsiveness, speed performance, and overall site structure, all of which influence rankings. Additionally, indexing images can boost your presence in image searches. Blocking these assets in robots.txt risks hindering the rendering of your pages, leading to partial or incorrect assessments of your site’s quality and may also forfeit potential search traffic from image or asset-specific queries.

## Issues

https://github.com/coldbox-templates/default/issues/25

## Type of change

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
