### PR TITLE
Remove ARG_VAR_MIXED from default linting rules

### DIFF
--- a/.cflintrc
+++ b/.cflintrc
@@ -21,9 +21,6 @@
             "code": "ARG_VAR_CONFLICT"
         },
         {
-            "code": "ARG_VAR_MIXED"
-        },
-        {
             "code": "CFQUERYPARAM_REQ"
         },
         {


### PR DESCRIPTION
# Description

It's extremely common in Coldbox handlers to reference `event`, `rc`, and `prc` without including `arguments` beforehand. I recommend removing this linting rule.  There's no need to have the linter display an error for this practice.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
